### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @knocklabs/product


### PR DESCRIPTION
Adds product team as codeowners like other language SDKs